### PR TITLE
Reporting

### DIFF
--- a/pywhip/collect.py
+++ b/pywhip/collect.py
@@ -14,18 +14,33 @@ from pywhip.validators import DwcaValidator
 from dwca.read import DwCAReader
 
 
-def normalize_list(messages):
+def whip_dwca(dwca_zip, specifications, maxentries=None):
     """"""
-    normalized = []
-    for message in messages:
-        if isinstance(message, str):
-            normalized.append(message)
-        elif isinstance(message, dict):
-            for value in message.values():
-                normalized += normalize_list(value)
-        else:
-            NotImplemented
-    return normalized
+    # Extract data header - only core support
+    with DwCAReader(dwca_zip) as dwca:
+        field_names = [field['term'].split('/')[-1] for field in
+                       dwca.core_file.file_descriptor.fields]
+
+    # Apply whip
+    whip_it = Whip(specifications)
+    whip_it._whip(whip_it.generate_dwca(dwca_zip),
+                  field_names, maxentries)
+    return whip_it
+
+
+def whip_csv(csv_file, specifications, maxentries=None):
+    """"""
+
+    # Extract data header
+    with open(csv_file, "r") as dwc:
+        reader = csv.DictReader(dwc, delimiter="\t")
+        field_names = reader.fieldnames
+
+    # Apply whip
+    whip_it = Whip(specifications)
+    whip_it._whip(whip_it.generate_csv(csv_file),
+                  field_names, maxentries)
+    return whip_it
 
 
 class Whip(object):
@@ -33,6 +48,7 @@ class Whip(object):
     def __init__(self, schema,
                  lowercase_terms=False):
 
+        # TODO: change:
         if isinstance(schema, str):
             schema = yaml.load(schema)
 
@@ -43,6 +59,13 @@ class Whip(object):
 
         # setup a DwcaValidator instance
         self.validation = DwcaValidator(self.schema)
+
+        self.report = {'number_of_records': 0,
+                       'executed_at': None,
+                       'unvalidated_fields': None,  # exist in dataset, not in specs
+                       'missing_fields': None,  # exist in specs, not in data set
+                       'errors': {},
+                       }
 
         self.errors = {}
         self._errorlog = defaultdict(lambda: defaultdict(list))
@@ -55,6 +78,45 @@ class Whip(object):
             lowercase_schema[dwcterm.lower()] = specification
         return lowercase_schema
 
+    def _compare_headers(self, file_fields):
+        """Compare data fields and specifications
+
+        Compare the fields mentioned by the specifications schema and the
+        data set and update thereport attributes on unvalidated and missing
+        fields
+
+        Parameters
+        ----------
+        file_fields : list
+            All fields present in the data-set.
+        """
+        try:
+            file_fields = set(file_fields)
+        except TypeError:
+            raise TypeError
+
+        self.report['unvalidated_fields'] = file_fields.difference(
+            set(self.schema.keys()))
+        self.report['missing_fields'] = set(self.schema.keys()).difference(
+            file_fields)
+
+    def _whip(self, input_generator, field_names, maxentries=None):
+        """"""
+
+        # preliminar checks
+        self._compare_headers(field_names)
+
+        # validate each row and log the errors for each row
+        for j, row in enumerate(input_generator):
+            self.validation.validate(row)
+            if len(self.validation.errors) > 0:
+                self.errors[j+1] = self.validation.errors
+            if maxentries:
+                if j >= maxentries-1:
+                    break
+        self._error_list_ids()
+        self._isitgreat()
+
     def _isitgreat(self):
         """check if there are any errors recorded"""
         if len(self.errors) == 0:
@@ -63,43 +125,28 @@ class Whip(object):
             print('Dataset does not comply the specifications, check errors'
                   ' for a more detailed information.')
 
-    def whip_dwca(self, dwca_zip, maxentries=None):
+    @staticmethod
+    def generate_dwca(dwca_zip):
         """"""
         with DwCAReader(dwca_zip) as dwca:
-            for j, row in enumerate(dwca):
+            for row in dwca:
                 document = {k.split('/')[-1]: v for k, v in row.data.items()}
+                yield document
 
-                # validate each row and log the errors for each row
-                self.validation.validate(document)
-                if len(self.validation.errors) > 0:
-                    self.errors[j+1] = self.validation.errors
-                if maxentries:
-                    if j >= maxentries-1:
-                        break
-        self._error_list_ids()
-        self._isitgreat()
-
-    def whip_csv(self, csv, delimiter, maxentries=None):
+    @staticmethod
+    def generate_csv(csv_file, delimiter):
         """"""
-        with open(csv, "r") as dwc:
+        with open(csv_file, "r") as dwc:
             reader = csv.DictReader(dwc, delimiter=delimiter)
-            for j, document in enumerate(reader):
-                self.validation.validate(document)
-                if len(self.validation.errors) > 0:
-                    self.errors[j+1] = self.validation.errors
-                if maxentries:
-                    if j >= maxentries-1:
-                        break
-
-        self._error_list_ids()
-        self._isitgreat()
+            for document in reader:
+                yield document
 
     def _error_list_ids(self):
         """"""
         for ids, errordict in self.errors.items():
             for term, errormessage in errordict.items():
                 if isinstance(errormessage, list):
-                    errormessage = normalize_list(errormessage)
+                    errormessage = self.normalize_list(errormessage)
                     for error in errormessage:
                         self._errorlog[term][error].append(ids)
 
@@ -134,3 +181,16 @@ class Whip(object):
         for terms, errors in self._errorlog.items():
             error_types += [error for error in errors.keys()]
         return error_types
+
+    def normalize_list(self, messages):
+        """"""
+        normalized = []
+        for message in messages:
+            if isinstance(message, str):
+                normalized.append(message)
+            elif isinstance(message, dict):
+                for value in message.values():
+                    normalized += self.normalize_list(value)
+            else:
+                NotImplemented
+        return normalized

--- a/pywhip/collect.py
+++ b/pywhip/collect.py
@@ -31,8 +31,7 @@ def normalize_list(messages):
 class Whip(object):
 
     def __init__(self, schema,
-                 lowercase_terms=False,
-                 unknown_fields=True):
+                 lowercase_terms=False):
 
         if isinstance(schema, str):
             schema = yaml.load(schema)
@@ -44,7 +43,6 @@ class Whip(object):
 
         # setup a DwcaValidator instance
         self.validation = DwcaValidator(self.schema)
-        self.validation.allow_unknown = unknown_fields
 
         self.errors = {}
         self._errorlog = defaultdict(lambda: defaultdict(list))

--- a/pywhip/collect.py
+++ b/pywhip/collect.py
@@ -7,6 +7,7 @@ Created on Wed May 18 11:08:55 2016
 
 import csv
 import yaml
+from datetime import datetime
 
 from collections import defaultdict, Mapping, Sequence
 
@@ -128,10 +129,10 @@ class Whip(object):
         except TypeError:
             raise TypeError
 
-        self.report['unvalidated_fields'] = file_fields.difference(
-            set(self.schema.keys()))
-        self.report['missing_fields'] = set(self.schema.keys()).difference(
-            file_fields)
+        self.report['unvalidated_fields'] = list(file_fields.difference(
+            set(self.schema.keys())))
+        self.report['missing_fields'] = list(set(self.schema.keys()).difference(
+            file_fields))
 
     def _whip(self, input_generator, field_names, maxentries=None):
         """"""
@@ -148,7 +149,11 @@ class Whip(object):
             if maxentries:
                 if j >= maxentries-1:
                     break
+
+        self.report['number_of_records'] = j + 1
+        self.report['executed_at'] = datetime.now().strftime("%Y-%m-%d %H:%M")
         self._error_list_ids()
+        self.report['errors'] = self._errorlog
         self._isitgreat()
 
     def _isitgreat(self):

--- a/pywhip/validators.py
+++ b/pywhip/validators.py
@@ -19,9 +19,8 @@ from cerberus import errors
 from cerberus.errors import ErrorDefinition
 from cerberus.platform import _str_type, _int_types
 
-toy_error_handler = errors.ToyErrorHandler()
-DELIMITER_SCHEMA = ErrorDefinition(0x82, 'delimitedvalues')
-IF_SCHEMA = ErrorDefinition(0x82, 'if')
+DELIMITER_SCHEMA = ErrorDefinition(0x85, 'delimitedvalues')
+IF_SCHEMA = ErrorDefinition(0x86, 'if')
 
 
 class DwcaValidator(Validator):

--- a/pywhip/validators.py
+++ b/pywhip/validators.py
@@ -351,7 +351,7 @@ class DwcaValidator(Validator):
                 # when the conditional field is not existing in the document,
                 # ignore the if-statement
                 if not set(conditions.keys()).issubset(
-                    set(self.document_str_version.keys())):
+                        set(self.document_str_version.keys())):
                     return True
 
                 if tempvalidator.validate(copy(self.document_str_version),

--- a/pywhip/validators.py
+++ b/pywhip/validators.py
@@ -60,7 +60,6 @@ class DwcaValidator(Validator):
 
         # Extend schema with empty: False by default
         self.schema = self._schema_add_empty(self.schema)
-        self.schema = self._schema_add_required(self.schema)
 
     def validate(self, document, *args, **kwargs):
         """adds document parsing to the validation process
@@ -82,16 +81,6 @@ class DwcaValidator(Validator):
         for term, rules in dict_schema.items():
             if 'empty' not in rules.keys():
                 rules['empty'] = False
-        return dict_schema
-
-    @staticmethod
-    def _schema_add_required(dict_schema):
-        """the required rule should be added for each of the fields, as whip
-        defines enlisted as default required
-        """
-        for term, rules in dict_schema.items():
-            if 'required' not in rules.keys():
-                rules['required'] = True
         return dict_schema
 
     def _validate_empty(self, empty, field, value):

--- a/pywhip/validators.py
+++ b/pywhip/validators.py
@@ -348,6 +348,12 @@ class DwcaValidator(Validator):
                 tempvalidator = DwcaValidator(conditions)
                 tempvalidator.allow_unknown = True
 
+                # when the conditional field is not existing in the document,
+                # ignore the if-statement
+                if not set(conditions.keys()).issubset(
+                    set(self.document_str_version.keys())):
+                    return True
+
                 if tempvalidator.validate(copy(self.document_str_version),
                                           normalize=True):
                     validator = self._get_child_validator(
@@ -398,7 +404,7 @@ class DwcaValidator(Validator):
         # provide support for if-statements -> add field from root document
         if 'if' in ruleset.keys():
             term = [key for key in ruleset['if'].keys() if
-                     isinstance(ruleset['if'][key], dict)]
+                    isinstance(ruleset['if'][key], dict)]
             if len(term) > 1:  # multiple if statements  not supported
                 NotImplementedError
             else:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1386,7 +1386,7 @@ class TestRequiredValidator(unittest.TestCase):
                                     allowed: many
                                   eventDate:
                                     dateformat: '%Y-%m-%d'  
-                                    required: True                    
+                                    required: True                  
                                   """
 
         self.yaml_presence_check = """
@@ -1418,9 +1418,13 @@ class TestRequiredValidator(unittest.TestCase):
         self.assertEqual(val.errors, {'eventDate': ['required field']})
 
     def test_default_required(self):
-        """ by default, all listed terms are required - a virtual 'required'
-        is added to the schema for each listed term"""
-        """ by default, all listed terms are required"""
+        """ the handling of required specification is handled on data set
+        level, so the individual specification is not using required as a
+        rule
+
+        Still, requried can be added to have the errors explicitly taken into
+        row-evaluation.
+        """
         schema = yaml.load(self.yaml_multiple_term)
         val = DwcaValidator(schema)
 
@@ -1430,7 +1434,7 @@ class TestRequiredValidator(unittest.TestCase):
 
         document = {'eventDate': '2018-01-01'}
         val.validate(document)
-        self.assertEqual(val.errors, {'abundance': ['required field']})
+        self.assertEqual(val.errors, {})
 
     def test_check_presence_only(self):
         """A minimal check on the presence of a specific column can be
@@ -1444,7 +1448,7 @@ class TestRequiredValidator(unittest.TestCase):
         self.assertTrue(val.validate(document))
         document = {'eventDate': ''}
         val.validate(document)
-        self.assertEqual(val.errors, {'abundance': ['required field']})
+        self.assertEqual(val.errors, {})
 
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1394,6 +1394,20 @@ class TestRequiredValidator(unittest.TestCase):
                                      empty: True                   
                                    """
 
+        self.yaml_presence_inside_if = """
+                                        coordinateUncertaintyInMeters:
+                                          empty: true
+                                          if:
+                                            - verbatimCoordinateSystem:
+                                                allowed: UTM 1km
+                                              numberformat: x
+                                              allowed: '707'
+                                            - verbatimCoordinateSystem:
+                                                allowed: UTM 5km
+                                              numberformat: x
+                                              allowed: '3536'
+                                        """
+
     def test_allow_unknown_argument(self):
         """by providing the allow_unkown argument, not-mentioned fields are
          allowed or not in the document"""
@@ -1450,7 +1464,18 @@ class TestRequiredValidator(unittest.TestCase):
         val.validate(document)
         self.assertEqual(val.errors, {})
 
+    def test_check_presence_on_if(self):
+        """When a field is mentioned inside an if condition, the condition
+        can not be checked. Warning is provided in the general whip-environment
+        as a preliminar check, here the if-statements are not executed
+        (no errors generated)"""
 
+        schema = yaml.load(self.yaml_presence_inside_if)
+        val = DwcaValidator(schema)
+
+        document = {'coordinateUncertaintyInMeters': '22'}
+        val.validate(document)
+        self.assertEqual(val.errors, {})
 
 
 


### PR DESCRIPTION
This PR provides a new version of the reporting json-format, with more metadata and information from preliminar checks. 

```
report = {'number_of_records': 0,  # totan number of evaluated rows
                       'executed_at': None,   # datetime of evaluation
                       'unvalidated_fields': None,  # exist in dataset, not in whip specs
                       'missing_fields': None,  # exist in whip specs, not in data set
                       'errors': {},  # Main field, containing the error-listing
                       'warnings': []  # additional warnings from the preliminar check(s)
                       }
```