### PR TITLE
Also bump version number to 0.3.3 in two other files

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -112,3 +112,17 @@ To run a subset of tests::
 
 $ py.test tests.test_pywhip
 
+Note for maintainers
+--------------------
+
+The repo uses the `bumpversion` package to keep track of the package version. use the following commands to switch the version:
+
+#. ``bumpversion patch`` to increase version from 1.0.0 to 1.0.1.
+#. ``bumpversion minor`` to increase version from 1.0.0 to 1.1.0.
+#. ``bumpversion major`` to increase version from 1.0.0 to 2.0.0.
+
+and push these tags to Github: `git push --tags` to create the release.
+
+
+
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.2
+current_version = 0.3.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ test_requirements = [
 
 setup(
     name='pywhip',
-    version='0.3.2',
+    version='0.3.3',
     description="Python package to validate data against whip specifications",
     long_description=readme + '\n\n' + history,
     author="Stijn Van Hoey",


### PR DESCRIPTION
I only bumped the version number in __init__.py: https://github.com/inbo/pywhip/commit/fae3d0dc5d6d8c862b2a45401383a2ee0ffeb227 (on master 😬), failing the build.

In this PR I manually updated it in two more files, cf. https://github.com/inbo/pywhip/commits/fae3d0dc5d6d8c862b2a45401383a2ee0ffeb227/pywhip/__init__.py

@stijnvanhoey is there a way to only update it in one place and have it bumped in all necessary files?