### PR TITLE
Hotfix: update cerberus dependency to 1.3.4 + support Python 3.8+

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,17 +2,19 @@
 History
 =======
 
-Current
+0.3.4 (2022-12-16)
 -------
-* Dropped support for Python 3.4
-* Added official support for Python 3.7 and 3.8
+* Add support for Python 3.7 and 3.8
+* Drop support for Python 3.4
+* Make use of cerberus 1.3.4
 
-0.3.3
+0.3.3 (2020-02-27)
 -----
+* Fix typo in error message
 
 0.3.2 (2018-08-27)
 ------------------
-* Hot fix on CLI tests
+* Hotfix on CLI tests
 
 0.3.1 (2018-08-27)
 ------------------
@@ -32,6 +34,6 @@ Current
 0.1.1 (2017-09-12)
 ------------------
 
-* First release on PyPI.
+* First release on PyPI
 * Package structure with CI integration
 * tox testing on multiple Python versions

--- a/pywhip/__init__.py
+++ b/pywhip/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Stijn Van Hoey"""
 __email__ = 'stijn.vanhoey@gmail.com'
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 
 from .pywhip import Whip, whip_dwca, whip_csv
 

--- a/pywhip/pywhip.py
+++ b/pywhip/pywhip.py
@@ -3,7 +3,11 @@
 import os
 import csv
 from datetime import datetime
-from collections import Mapping, Sequence
+try:
+    from collections.abc import Mapping, Sequence
+except:
+    from collections import Mapping, Sequence
+    
 from pkg_resources import resource_filename
 
 from dwca.read import DwCAReader

--- a/pywhip/reporters.py
+++ b/pywhip/reporters.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
 try:
-    from collections.abc import Mapping, defaultdict
+    from collections.abc import Mapping
 except:
-    from collections import Mapping, defaultdict
-
+    from collections import Mapping
+from collections import defaultdict
 
 class WhipReportException(Exception):
     """Raised when the reporting of the errors contains errors"""

--- a/pywhip/reporters.py
+++ b/pywhip/reporters.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from collections import Mapping, defaultdict
+try:
+    from collecitons.abc import Mapping, defaultdict
+except:
+    from collections import Mapping, defaultdict
 
 
 class WhipReportException(Exception):

--- a/pywhip/reporters.py
+++ b/pywhip/reporters.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 try:
-    from collecitons.abc import Mapping, defaultdict
+    from collections.abc import Mapping, defaultdict
 except:
     from collections import Mapping, defaultdict
 

--- a/pywhip/validators.py
+++ b/pywhip/validators.py
@@ -4,7 +4,10 @@ import re
 from copy import copy
 from datetime import datetime, date
 from dateutil.parser import parse
-from collections import Mapping, Sequence
+try:
+    from collections.abc import Mapping, Sequence
+except:
+    from collections import Mapping, Sequence
 
 import json
 # https://pypi.python.org/pypi/rfc3987 regex on URI's en IRI's
@@ -187,7 +190,10 @@ class DwcaValidator(Validator):
         """ {'type': 'boolean'} """
         # Dropping all remaining rules except of if (instead of subselection)
         # when empty = True
-        from collections import Sized
+        try:
+            from collections.abc import Sized
+        except: 
+            from collections import Sized
         if isinstance(value, Sized) and len(value) == 0:
             # ALL rules, except of if
             self._drop_remaining_rules(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Click>=6.0
 python-dwca-reader==0.13.0
-cerberus==1.2
+cerberus==1.3.4
 pyaml==17.12.1
 rfc3987==1.3.7
 python-dateutil==2.7.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.3
+current_version = 0.3.4
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ test_requirements = [
 
 setup(
     name='pywhip',
-    version='0.3.3',
+    version='0.3.4',
     description="Python package to validate data against whip specifications",
     long_description=readme,
     long_description_content_type='text/markdown',
@@ -50,6 +50,9 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10'
     ],
     test_suite='tests',
     tests_require=test_requirements,


### PR DESCRIPTION
Local installation via pip failed because of the cerberus dependency, this pull request is a hotfix to raise this dependency to the most recent version of cerberus. 

Also adds support for more recent Python versions: resolves #65 by using exception handling as per: https://stackoverflow.com/questions/53978542/how-to-use-collections-abc-from-both-python-3-8-and-python-2-7

There is a release on test pypi, ignore the version number, I've had a bit of a struggle testing; https://test.pypi.org/project/pywhip/

You should be able to install this version with:

```
pip install -i https://test.pypi.org/simple/ pywhip==0.3.7
```

You might have to set an extra index for the dependencies, like this:

```{bash}
python3 -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pywhip==0.3.7
```
